### PR TITLE
remove default classes

### DIFF
--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -26,7 +26,7 @@
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      class="heroicon solid {customClass}"
+      class="{customClass}"
       aria-hidden={ariaHidden}
       width={size}
       height={size}
@@ -43,7 +43,7 @@
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      class="heroicon outline {customClass}"
+      class="{customClass}"
       aria-hidden={ariaHidden}
       width={size}
       height={size}


### PR DESCRIPTION
These are common and generic class names that may collide with existing names.

Tailwind CSS for example provides an `outline` class to add outlines, causing this unwanted styling.
![image](https://user-images.githubusercontent.com/79615454/146967304-0cc67405-0462-4e8d-911d-bf29d3b7278f.png)
![image](https://user-images.githubusercontent.com/79615454/146967380-9a86b1f9-06ca-40a5-b036-1881d32ac305.png)

Note: This will be a breaking change for those who intentionally styled their icons using the removed classes.

An alternative option would be to rename these classes to something less generic like `svelte-hero-icons-outline`, though I would very much rather have full control over the icon classes.